### PR TITLE
Fix SME role for icesentry

### DIFF
--- a/_roles.toml
+++ b/_roles.toml
@@ -24,5 +24,5 @@ sme = [
     {area="Reflection", id="MrGVSV"},
     {area="Rendering", id="robtfm"},
     {area="Rendering", id="superdump"},
-    {area="Rendering", id="IceSentry"}
+    {area="Rendering", id="icesentry"}
 ]


### PR DESCRIPTION
My card had my username in all lowercase and it looks like the id field for the roles is case sensitive